### PR TITLE
Fix calling-card issues

### DIFF
--- a/scripts/astpp-callingcard-functions.pl
+++ b/scripts/astpp-callingcard-functions.pl
@@ -90,6 +90,8 @@ sub auth_callingcard()
                 $authenticated = 1;
                 $pin=$cardinfo->{pin};
             }
+            # Flush dtmf digit on queue
+            $session->flushDigits();
             $retries++;
          }
          

--- a/scripts/astpp-common.pl
+++ b/scripts/astpp-common.pl
@@ -89,7 +89,8 @@ sub validate_card_usage() {
         if ( $arg{carddata}->{validfordays} > 0 )
         {
             #Check if the card is set to expire and deal with that as appropriate.            
-            &insert_update_query("Update expiry","UPDATE accounts SET expiry = DATE_ADD($now, INTERVAL " . " $arg{carddata}->{validfordays} day) WHERE id = ".$arg{carddata}->{id});
+            &insert_update_query("Update expiry","UPDATE accounts SET expiry = DATE_ADD('$now', INTERVAL " . " $arg{carddata}->{validfordays} day) WHERE id = ".$arg{carddata}->{id});
+            return 0;
         }
     }
     elsif ($arg{carddata}->{validfordays} > 0 ){


### PR DESCRIPTION
- Fix new callingcard expiring after first usage due to failure to
update expiry date value in database
- Fix long dtmf entry (more than account length) on callingcard number
authentication